### PR TITLE
chore: fix release workflow race condition

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,14 @@
 name: Release
 
 on:
+  workflow_run:
+    workflows: ['Auto Changeset']
+    types: [completed]
   push:
-    branches:
-      - main
+    branches: [main] # keep this so publishing still happens after the version PR merge
+    paths:
+      - '**/package.json'
+      - '**/CHANGELOG.md'
 
 concurrency: ${{ github.workflow }}-${{ github.ref }}
 


### PR DESCRIPTION
This pull request updates the release workflow configuration to improve automation and control over when releases are triggered. The main change is to trigger the release workflow both after the completion of the "Auto Changeset" workflow and on pushes to the main branch that affect relevant files.

Workflow trigger improvements:

* The release workflow now runs when the "Auto Changeset" workflow completes, in addition to pushes to the `main` branch.
* The push trigger is restricted to changes affecting `package.json` and `CHANGELOG.md` files, ensuring releases are only published after relevant updates.