### PR TITLE
fix: redirect output

### DIFF
--- a/scripts/generate-changesets.sh
+++ b/scripts/generate-changesets.sh
@@ -48,7 +48,7 @@ discover_packages() {
       else
         packages="$package_name"
       fi
-      echo "  Found changes in $package_dir -> $package_name"
+      echo "  Found changes in $package_dir -> $package_name" >&2
     fi
   done < <(find packages/ -name "package.json" -print0 2>/dev/null || true)
   


### PR DESCRIPTION
This pull request includes a minor update to the logging behavior in the `discover_packages()` function of `scripts/generate-changesets.sh`. The change redirects the output of the "Found changes" message to standard error, which helps separate informational messages from standard output.

* Logging improvement:
  * [`scripts/generate-changesets.sh`](diffhunk://#diff-ebf6a4f8778614e661111d81aa78d8856b24ffd39a35c5c8633199b718791d35L51-R51): Changed the "Found changes in $package_dir -> $package_name" message to be printed to standard error instead of standard output.