### PR TITLE
chore: refactor commit should bump

### DIFF
--- a/scripts/generate-changesets.sh
+++ b/scripts/generate-changesets.sh
@@ -64,7 +64,7 @@ get_version_bump() {
     echo "major"
   elif [[ "$commit_type" == "feat" ]]; then
     echo "minor"
-  elif [[ "$commit_type" =~ ^(fix|perf)$ ]]; then
+  elif [[ "$commit_type" =~ ^(fix|perf|refactor|style|chore)$ ]]; then
     echo "patch"
   else
     echo ""  # No version bump for other types


### PR DESCRIPTION
This pull request makes a small update to the `get_version_bump()` function in `scripts/generate-changesets.sh` to improve how commit types are mapped to version bump levels.

* The function now treats `refactor`, `style`, and `chore` commit types as patch-level changes, in addition to the previously supported `fix` and `perf` types.